### PR TITLE
Updated Python Requirements

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ click==6.7
 Flask==1.1.1
 itsdangerous==0.24
 Jinja2==2.11.3
-MarkupSafe==2.1.1
+MarkupSafe==2.0.1
 requests==2.20.0
 Werkzeug==0.15.5
 curlify==1.2.1


### PR DESCRIPTION
- rolled bcak to working `MarkupSafe` version